### PR TITLE
Bug fix - Error when selecting after delete

### DIFF
--- a/CTkListbox/ctk_listbox.py
+++ b/CTkListbox/ctk_listbox.py
@@ -112,6 +112,7 @@ class CTkListbox(customtkinter.CTkScrollableFrame):
             return
         self.buttons[index].destroy()
         del self.buttons[index]
+        self.selections.clear()
         
     def size(self):
         """ return total number of items in the listbox """


### PR DESCRIPTION
with multiple_selection=true, during delete of items from listbox, i observed once after delete, I was getting an error whenever i select the remaining items in list. This change will fix that. I am clearing the items from self.selections list.