### PR TITLE
Add feature: Option reordering

### DIFF
--- a/CTkListbox/ctk_listbox.py
+++ b/CTkListbox/ctk_listbox.py
@@ -229,3 +229,53 @@ class CTkListbox(customtkinter.CTkScrollableFrame):
             self.command = kwargs.pop("command")
             
         super().configure(**kwargs)
+
+    def move_up(self, index):
+        """ Move the option up in the listbox """
+        if index > 0:
+            current_key = list(self.buttons.keys())[index]
+            previous_key = list(self.buttons.keys())[index - 1]
+
+
+            # Store the text of the button to be moved
+            current_text = self.buttons[current_key].cget("text")
+
+            # Update the text of the buttons
+            self.buttons[current_key].configure(text=self.buttons[previous_key].cget("text"))
+            self.buttons[previous_key].configure(text=current_text)
+
+
+            # Clear the selection from the current option
+            selected = list(self.buttons.keys())[index]
+            self.deselect(selected)
+            
+            # Update the selection
+            self.selected = self.buttons[previous_key]
+            self.selected.configure(fg_color=self.select_color, hover=False)
+            self.after(100, lambda: self.selected.configure(hover=self.hover))
+
+    def move_down(self, index):
+        """ Move the option down in the listbox """
+        if index < len(self.buttons) - 1:
+            current_key = list(self.buttons.keys())[index]
+            next_key = list(self.buttons.keys())[index + 1]
+
+            # Store the text of the button to be moved
+            current_text = self.buttons[current_key].cget("text")
+
+            # Update the text of the buttons
+            self.buttons[current_key].configure(text=self.buttons[next_key].cget("text"))
+            self.buttons[next_key].configure(text=current_text)
+
+            # Clear the selection from the current option
+            self.deselect(current_key)
+
+            # Update the selection
+            self.selected = self.buttons[next_key]
+            self.selected.configure(fg_color=self.select_color, hover=False)
+            self.after(100, lambda: self.selected.configure(hover=self.hover))
+
+            # Update the display order
+            for i, button in enumerate(self.buttons.values()):
+                button.pack_forget()
+                button.pack(padx=0, pady=(0, 5), fill="x", expand=True)

--- a/CTkListbox/ctk_listbox.py
+++ b/CTkListbox/ctk_listbox.py
@@ -236,7 +236,6 @@ class CTkListbox(customtkinter.CTkScrollableFrame):
             current_key = list(self.buttons.keys())[index]
             previous_key = list(self.buttons.keys())[index - 1]
 
-
             # Store the text of the button to be moved
             current_text = self.buttons[current_key].cget("text")
 
@@ -244,15 +243,15 @@ class CTkListbox(customtkinter.CTkScrollableFrame):
             self.buttons[current_key].configure(text=self.buttons[previous_key].cget("text"))
             self.buttons[previous_key].configure(text=current_text)
 
-
             # Clear the selection from the current option
-            selected = list(self.buttons.keys())[index]
-            self.deselect(selected)
+            self.deselect(current_key)
             
             # Update the selection
-            self.selected = self.buttons[previous_key]
-            self.selected.configure(fg_color=self.select_color, hover=False)
-            self.after(100, lambda: self.selected.configure(hover=self.hover))
+            self.select(previous_key)
+
+            # Update the scrollbar position
+            self._parent_canvas.yview("scroll", -int(100 / 6), "units")
+
 
     def move_down(self, index):
         """ Move the option down in the listbox """
@@ -271,11 +270,7 @@ class CTkListbox(customtkinter.CTkScrollableFrame):
             self.deselect(current_key)
 
             # Update the selection
-            self.selected = self.buttons[next_key]
-            self.selected.configure(fg_color=self.select_color, hover=False)
-            self.after(100, lambda: self.selected.configure(hover=self.hover))
+            self.select(next_key)
 
-            # Update the display order
-            for i, button in enumerate(self.buttons.values()):
-                button.pack_forget()
-                button.pack(padx=0, pady=(0, 5), fill="x", expand=True)
+            # Update the scrollbar position
+            self._parent_canvas.yview("scroll", int(100 / 6), "units")

--- a/CTkListbox/ctk_listbox.py
+++ b/CTkListbox/ctk_listbox.py
@@ -250,7 +250,8 @@ class CTkListbox(customtkinter.CTkScrollableFrame):
             self.select(previous_key)
 
             # Update the scrollbar position
-            self._parent_canvas.yview("scroll", -int(100 / 6), "units")
+            if self._parent_canvas.yview() != (0.0, 1.0):
+                self._parent_canvas.yview("scroll", -int(100 / 6), "units")
 
 
     def move_down(self, index):
@@ -273,4 +274,5 @@ class CTkListbox(customtkinter.CTkScrollableFrame):
             self.select(next_key)
 
             # Update the scrollbar position
-            self._parent_canvas.yview("scroll", int(100 / 6), "units")
+            if self._parent_canvas.yview() != (0.0, 1.0):
+                self._parent_canvas.yview("scroll", int(100 / 6), "units")


### PR DESCRIPTION
This pull request addresses the open issue #17 by introducing a new feature: Option Reordering. Users can now easily reorder options as needed. The changes include two new methods, move_up and move_down. This enhancement aims to resolve the reported issue and improve the overall usability of the widget.

Below is an example code snippet demonstrating how the new option reordering feature can be implemented by users:

```
import customtkinter
from CTkListbox import *

# Create the main application window
root = customtkinter.CTk()

# Function to move the selected item up in the list
def moveup():
    index = animalBox.curselection()
    if index > 0:
        animalBox.move_up(index)
        animalList[index - 1], animalList[index] = animalList[index], animalList[index - 1]

# Function to move the selected item down in the list
def movedown():
    index = animalBox.curselection()
    if index < animalBox.size() - 1:
        animalBox.move_down(index)
        animalList[index], animalList[index + 1] = animalList[index + 1], animalList[index]

# Function to handle the selection event in the listbox
def show_value(selected_option):
    print(selected_option)

# Initial list of animals
animalList = ['Cat', 'Dog', 'Bear', 'Dolphin', 'Kangaroo']

# Create a Tkinter StringVar with the initial list
animalString = customtkinter.StringVar(value=animalList)

# Create a custom listbox using CTkListbox
animalBox = CTkListbox(root, command=show_value, listvariable=animalString)
animalBox.grid(row=1, column=0, padx=20, pady=10)

# Create buttons for moving items up and down
moveupButton = customtkinter.CTkButton(root, text="Move Up", command=moveup, width=200, height=35)
moveupButton.grid(row=2, column=0, padx=20, pady=10)

movedownButton = customtkinter.CTkButton(root, text="Move Down", command=movedown, width=200, height=35)
movedownButton.grid(row=3, column=0, padx=20, pady=10)

# Start the Tkinter main loop
root.mainloop()

```