### PR TITLE
Fix dictionary inconsistency

### DIFF
--- a/CTkListbox/ctk_listbox.py
+++ b/CTkListbox/ctk_listbox.py
@@ -340,7 +340,6 @@ class CTkListbox(customtkinter.CTkScrollableFrame):
 
     def move_down(self, index):
         """Move the option down in the listbox"""
-        print(len(self.buttons) - 1)
         if index < len(self.buttons) - 1:
             next_index = index + 1
 

--- a/complex_example.py
+++ b/complex_example.py
@@ -45,13 +45,11 @@ def delete4To5():
 
 def move_up_current():
     index = listbox.curselection()
-    print(index)
     listbox.move_up(index)
 
 
 def move_down_current():
     index = listbox.curselection()
-    print(index)
     listbox.move_down(index)
 
 

--- a/complex_example.py
+++ b/complex_example.py
@@ -1,0 +1,85 @@
+import customtkinter
+
+from CTkListbox import *
+
+
+def show_value(selected_option):
+    print(selected_option)
+
+
+root = customtkinter.CTk()
+
+listbox = CTkListbox(root, command=show_value, multiple_selection=False)
+listbox.pack(fill="both", expand=True, padx=10, pady=10)
+
+listbox.insert("Option 0", index=0)
+listbox.insert("Option 1", index=1)
+listbox.insert("Option 2", index=2)
+listbox.insert("Option 3", index=3)
+listbox.insert("Option 4", index=4)
+listbox.insert("Option 5", index=5)
+listbox.insert("Option 6", index=6)
+listbox.insert("Option 7", index=7)
+listbox.insert("Option 8")
+
+
+def delete4ToEnd():
+    listbox.delete(index=4, last="end")
+
+
+def delete3():
+    listbox.delete(index=3)
+
+
+def delete4():
+    listbox.delete(index=4)
+
+
+def add0():
+    listbox.insert(option="New Option 0", index=0)
+
+
+def delete4To5():
+    listbox.delete(index=4, last=5)
+
+
+def move_up_current():
+    index = listbox.curselection()
+    print(index)
+    listbox.move_up(index)
+
+
+def move_down_current():
+    index = listbox.curselection()
+    print(index)
+    listbox.move_down(index)
+
+
+button = customtkinter.CTkButton(root, text="Delete Index 3", command=delete3)
+button.pack(fill="both", expand=True, padx=10, pady=10)
+
+button2 = customtkinter.CTkButton(root, text="Delete Index 4", command=delete4)
+button2.pack(fill="both", expand=True, padx=10, pady=10)
+
+button3 = customtkinter.CTkButton(
+    root, text="Delete Index 4 to the End", command=delete4ToEnd
+)
+button3.pack(fill="both", expand=True, padx=10, pady=10)
+
+button4 = customtkinter.CTkButton(root, text="Add at Index 0", command=add0)
+button4.pack(fill="both", expand=True, padx=10, pady=10)
+
+button5 = customtkinter.CTkButton(
+    root, text="Delete Index 4 to Index 5", command=delete4To5
+)
+button5.pack(fill="both", expand=True, padx=10, pady=10)
+
+button6 = customtkinter.CTkButton(root, text="Move Up Current", command=move_up_current)
+button6.pack(fill="both", expand=True, padx=10, pady=10)
+
+button7 = customtkinter.CTkButton(
+    root, text="Move Down Current", command=move_down_current
+)
+button7.pack(fill="both", expand=True, padx=10, pady=10)
+
+root.mainloop()


### PR DESCRIPTION
After having some issues with the elimination of options (issue #33), this changes implement the use of a single data structure, instead of using one and sometimes converting to another. Given that, the insert function was changed, where by default an element is added to the end of the list, but if the user specifies an index, the element is added to that index (or changed, if that index already exists).

All features seems to work without issues and a complex example is given. Any issues found, i'm open to try to fix it!