### PR TITLE
KeyError solved when deleting "END" key

### DIFF
--- a/CTkListbox/ctk_listbox.py
+++ b/CTkListbox/ctk_listbox.py
@@ -97,7 +97,7 @@ class CTkListbox(customtkinter.CTkScrollableFrame):
         """select the option"""
         for options in self.buttons.values():
             options.configure(fg_color=self.button_fg_color)
-        
+
         if isinstance(index, int):
             if index in self.buttons:
                 selected_button = self.buttons[index]
@@ -105,7 +105,7 @@ class CTkListbox(customtkinter.CTkScrollableFrame):
                 selected_button = list(self.buttons.values())[index]
         else:
             selected_button = self.buttons[index]
-  
+
         if self.multiple:
             if selected_button in self.selections:
                 self.selections.remove(selected_button)
@@ -236,8 +236,8 @@ class CTkListbox(customtkinter.CTkScrollableFrame):
             return
 
         if str(index).lower() == "end":
-            index = f"END{self.end_num}"
             self.end_num -= 1
+            index = f"END{self.end_num}"
         else:
             if int(index) >= len(self.buttons):
                 return

--- a/CTkListbox/ctk_listbox.py
+++ b/CTkListbox/ctk_listbox.py
@@ -316,7 +316,6 @@ class CTkListbox(customtkinter.CTkScrollableFrame):
             self.command = kwargs.pop("command")
         if "multiple_selection" in kwargs:
             self.multiple = kwargs.pop("multiple_selection")
-            print(self.multiple)
 
         super().configure(**kwargs)
 

--- a/CTkListbox/ctk_listbox.py
+++ b/CTkListbox/ctk_listbox.py
@@ -314,6 +314,9 @@ class CTkListbox(customtkinter.CTkScrollableFrame):
                 i.configure(font=self.font)
         if "command" in kwargs:
             self.command = kwargs.pop("command")
+        if "multiple_selection" in kwargs:
+            self.multiple = kwargs.pop("multiple_selection")
+            print(self.multiple)
 
         super().configure(**kwargs)
 


### PR DESCRIPTION
When deleting given the index "END", a KeyError occur. By changing the order of given the key to be deleted and the decrease of the variable end_num, solves this issue. 