### PR TITLE
Fix invisible text in light mode

### DIFF
--- a/CTkListbox/ctk_listbox.py
+++ b/CTkListbox/ctk_listbox.py
@@ -46,7 +46,7 @@ class CTkListbox(customtkinter.CTkScrollableFrame):
             else highlight_color
         )
         self.text_color = (
-            customtkinter.ThemeManager.theme["CTkButton"]["text_color"]
+            customtkinter.ThemeManager.theme["CTkLabel"]["text_color"]
             if text_color == "default"
             else text_color
         )


### PR DESCRIPTION
Using the label text color instead of the button text color fixes #52 

With this, light and dark mode are working properly.