### PR TITLE
fixed bug when call list.delete('all') for empty list

### DIFF
--- a/CTkListbox/ctk_listbox.py
+++ b/CTkListbox/ctk_listbox.py
@@ -184,7 +184,7 @@ class CTkListbox(customtkinter.CTkScrollableFrame):
             if self.multiple:
                 for i in self.buttons:
                     self.deselect(i)
-            else:
+            elif len(self.buttons):
                 self.deselect(0)
             return
         


### PR DESCRIPTION
self.list.delete('all')
  File "/home/usr/prj/venv/lib/python3.10/site-packages/CTkListbox/ctk_listbox.py", line 260, in delete
    self.deactivate("all")
  File "/home/usr/prj/venv/lib/python3.10/site-packages/CTkListbox/ctk_listbox.py", line 188, in deactivate
    self.deselect(0)
  File "/home/usr/prj/venv/lib/python3.10/site-packages/CTkListbox/ctk_listbox.py", line 178, in deselect
    if self.buttons[index] in self.selections:
KeyError: 0