### PR TITLE
Optimized delete all by updating only at the end

### DIFF
--- a/CTkListbox/ctk_listbox.py
+++ b/CTkListbox/ctk_listbox.py
@@ -174,7 +174,7 @@ class CTkListbox(customtkinter.CTkScrollableFrame):
             if self.selected:
                 self.selected.configure(fg_color=self.button_fg_color)
                 self.selected = None
-                return
+            return
         if self.buttons[index] in self.selections:
             self.selections.remove(self.buttons[index])
             self.buttons[index].configure(fg_color=self.button_fg_color)
@@ -260,7 +260,7 @@ class CTkListbox(customtkinter.CTkScrollableFrame):
             self.deactivate("all")
             for i in self.buttons:
                 self.buttons[i].destroy()
-                self.update()
+            self.update()
             self.buttons = {}
             self.end_num = 0
             return


### PR DESCRIPTION
When self.delete("all") is called a for loop destroys each button and updates every time. I changed it to only update at the end of the loop.